### PR TITLE
기간 계산을 분단위로

### DIFF
--- a/custom_components/kwh_to_won/kwh2won_api.py
+++ b/custom_components/kwh_to_won/kwh2won_api.py
@@ -242,7 +242,7 @@ class kwh2won_api:
         useDays = self._ret['useDays']
         monthDays = self._ret['monthDays']
 
-        forcest = round(energy / (((useDays - 1) * 24) + today.hour + 1) * (monthDays * 24), 1)
+        forcest = round(energy / ((((useDays - 1) * 24) + today.hour) * 60 + today.minute + 1) * (monthDays * 24 * 60 + 1), 1)
         _LOGGER.debug(f"########### 예상사용량:{forcest}, 월길이 {monthDays}, 사용일 {useDays}, 검침일 {checkDay}, 오늘 {today.day}")
         return {
             'forcest': forcest,


### PR DESCRIPTION
기존에 시간(hour) 단위로 사용량을 예상하다보니 예상사용량이 계단형태임.
이를 분(minute) 단위로 시간을 계산하게 하여 예상사용량을 좀 더 부드럽게 개선